### PR TITLE
Add already-processed pre-check, check_file_format CLI, clearer run r…

### DIFF
--- a/applications/billing-adjustments/README.md
+++ b/applications/billing-adjustments/README.md
@@ -192,6 +192,7 @@ Here is what each value means and what to do about it.
 |--------|-------|---------|------------|
 | `COMPLETED` | after submit (service) | The adjustment was accepted and fully processed by AWS. | Done — the refund is applied. |
 | `DRY_RUN_OK` | dry-run only | The invoice passed pre-flight validation and **would** be submitted in a live run. Nothing was submitted. | Re-run without dry-run to actually submit. |
+| `ALREADY_PROCESSED` | live pre-check (before submit) | The live run found an existing `COMPLETED` or `PENDING` adjustment request for this `<agreement, invoice>`, so the row was **skipped** (not resubmitted) to avoid a duplicate refund. The existing request id is recorded. | None needed — the refund already exists / is in flight. Use **Check one request** / `get_adjustment_request.py` with the recorded request id to review it. |
 | `VALIDATION_FAILED` | pre-submit check, **or** service terminal status | Two cases: (a) the row failed the pre-flight check — invoice not found, not an adjustable invoice type (e.g. `CREDIT_MEMO`), or amount > `maxAdjustmentAmount` — so **nothing was submitted**; or (b) a submitted request was rejected by the service during processing (e.g. KYC/compliance, agreement state). | Fix the input/data; the `message` column has the reason. Re-running unchanged won't help. |
 | `SUBMIT_FAILED` | submit (create call) | The row passed validation, the tool called `BatchCreateBillingAdjustmentRequest`, and that call rejected the entry or errored (throttling, permissions, conflict, API error). **No request was created.** | Usually retry-safe — the deterministic client token prevents duplicates. Check the `message`. |
 | `ERROR` | service terminal status | While polling, `GetBillingAdjustmentRequest` returned an error status for the request. | Investigate the `message`; may require AWS Marketplace support. |
@@ -346,6 +347,33 @@ for **8 hours** from the first request. What this means in practice:
   Do not rely on the token to prevent duplicates across days. The durable backstop is
   the per-invoice `maxAdjustmentAmount`: once an invoice has been refunded up to its
   maximum, further refunds are rejected regardless of the token.
+
+> **Recommended pre-flight: reconcile the input file before you submit.** Because the
+> 8-hour window can lapse between runs, the reliable way to avoid an accidental second
+> refund is to reconcile the *exact file you are about to submit* against the service
+> first — run **Check processed refunds** (web UI) or
+> `python check_processed_refunds.py <your-file.csv>` (CLI). Any `<agreement, invoice>`
+> that comes back in the **processed** output has already been refunded; treat that as a
+> warning to remove those rows (or confirm you truly intend to refund them again) before
+> running the live submit. This check does **not** depend on the idempotency window — it
+> works no matter how long ago the prior run happened, so it is the safest guard once
+> more than 8 hours may have passed.
+
+**Built-in live pre-check (automatic).** You don't have to remember to reconcile first —
+every **live run checks each `<agreement, invoice>` against the service immediately
+before submitting it.** If an existing `COMPLETED` or `PENDING` adjustment request is
+found, that row is **skipped** (status `ALREADY_PROCESSED`, the existing request id is
+recorded) instead of being resubmitted. Rows whose only prior request is
+`VALIDATION_FAILED` (no refund happened) are still submitted, so genuine retries are not
+blocked. This is what protects you once the 8-hour idempotency window has lapsed, and it
+is **on by default**. It also runs during a **dry run** (when enabled) as a preview, so
+the dry-run report labels already-refunded rows `ALREADY_PROCESSED` and the `DRY_RUN_OK`
+count reflects only genuinely new refunds — a warning before you commit to the live run.
+The CLI exposes `--no-precheck` to skip it (faster, for a verified
+fresh batch); the web app runs it automatically. Skipped rows appear in the run output —
+`already_processed_<input>_<timestamp>.csv` (CLI) or the job's `records` with status
+`ALREADY_PROCESSED` (web) — so you can review them with **Check one request** /
+`get_adjustment_request.py`.
 
 **Trade-off:** because the amount is intentionally *not* part of the token, you
 cannot issue two different refunds against the same invoice and agreement through the

--- a/applications/billing-adjustments/cli/README.md
+++ b/applications/billing-adjustments/cli/README.md
@@ -8,6 +8,7 @@ Process bulk billing adjustments (refunds) for AWS Marketplace sellers using the
 - **`check_adjustment_status.py`** — Checks the status of previously submitted adjustment requests
 - **`check_processed_refunds.py`** — Reconciles a refund input file against the service: lists each agreement's requests, confirms which input invoices were processed, and writes a processed file and a not-processed file
 - **`clean_refund_file.py`** — Pre-flight cleaner: splits an input file into a cleaned file (safe to submit, de-duplicated) and a `needs_review` file (invalid or duplicate rows, with a reason). Does not call AWS
+- **`check_file_format.py`** — Validates an input file's format (required columns, amount column, per-row issues) and prints a pass/fail report. Does not call AWS. CLI equivalent of the web UI's "Check file format" button
 - **`list_adjustment_requests.py`** — Queries `ListBillingAdjustmentRequests` across one or more agreements with optional status/date filters (CSV output)
 - **`get_adjustment_request.py`** — Looks up a single request (or a file of pairs) via `GetBillingAdjustmentRequest`
 
@@ -203,6 +204,20 @@ python billing_adjustment_bulk_sdk_creds.py adjustmentFiles/sample_company.csv
 
 If no CSV file is specified, defaults to `adjustmentFiles/sample_company.csv`.
 
+> **Live runs pre-check for already-processed refunds (on by default).** Before
+> submitting each row, a live run lists the agreement's existing adjustment requests and
+> **skips** any `<agreement, invoice>` that already has a `COMPLETED` or `PENDING`
+> request — writing it to `already_processed_<input>_<timestamp>.csv` (with the existing
+> request id) instead of resubmitting. This is the durable guard against duplicate
+> refunds once the API's 8-hour idempotency window has lapsed. Rows whose only prior
+> request is `VALIDATION_FAILED` are still submitted (genuine retries aren't blocked).
+> Pass `--no-precheck` to skip this step (faster, only for a batch you've already
+> verified is fresh):
+>
+> ```bash
+> python billing_adjustment_bulk_sdk_creds.py --no-precheck adjustmentFiles/sample_company.csv
+> ```
+
 > **Invalid and duplicate rows are handled automatically.** Before processing, the
 > script splits the input into rows that are safe to submit and rows that need
 > review. Rows with a missing or placeholder `agreement_id`/`invoice_id` (e.g.
@@ -211,6 +226,23 @@ If no CSV file is specified, defaults to `adjustmentFiles/sample_company.csv`.
 > plus a `review_reason`) and are **not** submitted. Only the first occurrence of
 > each `<agreement, invoice>` is processed. The path is also recorded in the results
 > JSON under `needs_review_file`.
+
+### Check File Format (No AWS Calls)
+
+To validate an input file's format **without** calling AWS or submitting anything —
+the CLI equivalent of the web UI's "Check file format" button:
+
+```bash
+python check_file_format.py adjustmentFiles/sample_company.csv
+# machine-readable output
+python check_file_format.py refunds.csv --json
+```
+
+It reports the columns found, any missing required columns, which amount column was
+detected (case-insensitive), the data-row count, and any row-level issues (missing
+`agreement_id`/`invoice_id`, non-positive amount, or more than 2 decimal places). It
+exits `0` when the file is valid and `1` when it is not, so it can gate a script. To
+also split a file into cleaned + needs-review outputs, use `clean_refund_file.py`.
 
 ### Clean a File Without Submitting (Pre-flight)
 
@@ -269,6 +301,19 @@ python list_adjustment_requests.py agmt-aaa agmt-bbb
 python list_adjustment_requests.py --agreements-file ids.txt \
     --status COMPLETED --created-after 2026-06-01 --created-before 2026-06-30
 ```
+
+> **API reference:** [`ListBillingAdjustmentRequests`](https://docs.aws.amazon.com/marketplace/latest/APIReference/API_marketplace-agreements_ListBillingAdjustmentRequests.html).
+> The script exposes every filter the API accepts **except `agreementType`** — the
+> service rejects that one in combination with the other filters ("combination of
+> filters is not supported"), so it is intentionally not sent. `nextToken` is handled
+> for you: the script paginates through all pages automatically unless you pass
+> `--max-results` (1–50), which returns a single page. Valid `--status` values are
+> `PENDING`, `VALIDATION_FAILED`, and `COMPLETED`.
+>
+> **Dates → timestamps:** `--created-after` / `--created-before` accept `YYYY-MM-DD`
+> (or full ISO). The script parses them to UTC datetimes (`--created-before` snaps to
+> end-of-day `23:59:59`), and boto3 serializes those to the numeric epoch **timestamp**
+> the API's `createdAfter` / `createdBefore` parameters expect.
 
 ### Look Up One Request
 
@@ -389,6 +434,7 @@ web app:
 | Status | Meaning |
 |--------|---------|
 | `DRY_RUN_OK` | Passed validation in dry-run (not submitted) |
+| `ALREADY_PROCESSED` | Live pre-check found an existing COMPLETED/PENDING request for this `<agreement, invoice>`; row skipped (not resubmitted). See `already_processed_<input>_<timestamp>.csv` |
 | `VALIDATION_FAILED` | Invoice not found, non-adjustable type, or amount exceeds max (pre-submit) |
 | `SUBMIT_FAILED` | The create call (`BatchCreateBillingAdjustmentRequest`) was rejected |
 | `COMPLETED` | Adjustment processed successfully |
@@ -440,6 +486,7 @@ for the shared list (`ResourceNotFoundException`, `REFUND_AMOUNT_EXCEEDS_MAXIMUM
 
 - [ ] Set up AWS credentials (see Credential Options above)
 - [ ] Place CSV file in `adjustmentFiles/` with required columns
+- [ ] Reconcile first (safety): `python check_processed_refunds.py <file.csv>` — if any `<agreement, invoice>` shows up as already processed, remove those rows or confirm you really intend to refund again (especially if >8h since any prior run, when the idempotency token no longer guards against duplicates)
 - [ ] Run dry-run: `python billing_adjustment_bulk_sdk_creds.py --dry-run <file.csv>`
 - [ ] Review dry-run output — check for validation failures and aggregate warnings
 - [ ] Run live: `python billing_adjustment_bulk_sdk_creds.py <file.csv>`

--- a/applications/billing-adjustments/cli/billing_adjustment_bulk_sdk_creds.py
+++ b/applications/billing-adjustments/cli/billing_adjustment_bulk_sdk_creds.py
@@ -59,19 +59,41 @@ def write_needs_review_file(review_rows, columns, csv_file):
     return path
 
 
+def write_already_processed_file(records, csv_file):
+    """Write rows skipped by the live pre-check (a COMPLETED/PENDING adjustment request
+    already exists) to already_processed_<input>_<timestamp>.csv. Includes the existing
+    request id so the user can look it up. Returns the path, or None if there were none."""
+    rows = [r for r in records if r.get('status') == 'ALREADY_PROCESSED']
+    if not rows:
+        return None
+    fields = ["agreement_id", "invoice_id", "billing_adjustment_request_id", "amount", "message"]
+    base = re.sub(r'[^A-Za-z0-9_-]', '_', os.path.splitext(os.path.basename(csv_file))[0])
+    path = f"already_processed_{base}_{datetime.now().strftime('%Y%m%d_%H%M%S')}.csv"
+    import csv as _csv
+    with open(path, 'w', newline='', encoding='utf-8') as f:
+        w = _csv.DictWriter(f, fieldnames=fields, extrasaction='ignore')
+        w.writeheader()
+        for r in rows:
+            w.writerow({k: r.get(k, "") for k in fields})
+    return path
+
+
 def parse_args():
     dry_run = False
+    precheck = True
     csv_file = CSV_FILE
     for arg in sys.argv[1:]:
         if arg == '--dry-run':
             dry_run = True
+        elif arg == '--no-precheck':
+            precheck = False
         elif arg.startswith('-'):
             print(f"Unknown option: {arg}")
-            print("Usage: python billing_adjustment_bulk_sdk_creds.py [--dry-run] [csv_file]")
+            print("Usage: python billing_adjustment_bulk_sdk_creds.py [--dry-run] [--no-precheck] [csv_file]")
             sys.exit(1)
         else:
             csv_file = arg
-    return dry_run, csv_file
+    return dry_run, csv_file, precheck
 
 
 def _amount(record):
@@ -105,6 +127,7 @@ def build_summary(records, dry_run):
     summary = {
         "validation_failed": count('VALIDATION_FAILED'),
         "submit_failed": count('SUBMIT_FAILED'),
+        "already_processed": count('ALREADY_PROCESSED'),
         "submitted": count('COMPLETED', 'ERROR', 'TIMEOUT'),
         "completed": count('COMPLETED'),
         "completion_failed": count('ERROR', 'TIMEOUT'),
@@ -123,9 +146,11 @@ def build_summary(records, dry_run):
 
 
 def main():
-    dry_run, csv_file = parse_args()
+    dry_run, csv_file, precheck = parse_args()
 
     print(f"Mode: {'DRY-RUN (validation only)' if dry_run else 'LIVE'}")
+    if not dry_run:
+        print(f"Already-processed pre-check: {'ON' if precheck else 'OFF (--no-precheck)'}")
     print("Using default AWS credential chain")
     print(f"\nLoading CSV: {csv_file}")
 
@@ -154,13 +179,22 @@ def main():
     counters = {}
 
     try:
-        engine_summary = processor.run(valid_records, collector, dry_run=dry_run, counters=counters)
+        engine_summary = processor.run(valid_records, collector, dry_run=dry_run,
+                                       counters=counters, precheck_processed=precheck)
     except CredentialsCancelled:
         print("\nStopped: fresh credentials were not provided.")
         engine_summary = {"cancelled": True}
 
     row_results = build_row_results(collector.records)
     summary = build_summary(collector.records, dry_run)
+
+    already_processed_file = write_already_processed_file(collector.records, csv_file)
+    if already_processed_file:
+        skipped = sum(1 for r in collector.records if r.get('status') == 'ALREADY_PROCESSED')
+        print(f"\n\u26a0 {skipped} row(s) skipped — already have a COMPLETED/PENDING refund "
+              f"and were NOT resubmitted.")
+        print(f"  Saved to: {already_processed_file}")
+        print("  Use the request id in that file with get_adjustment_request.py to review details.")
 
     output = {
         "timestamp": datetime.now().isoformat(),
@@ -169,6 +203,7 @@ def main():
         "total_rows": len(valid_records),
         "needs_review_rows": len(review_rows),
         "needs_review_file": review_file,
+        "already_processed_file": already_processed_file,
         "total_phases": engine_summary.get("total_phases"),
         "duplicate_invoices": engine_summary.get("duplicate_invoices", {}),
         "summary": summary,

--- a/applications/billing-adjustments/cli/check_file_format.py
+++ b/applications/billing-adjustments/cli/check_file_format.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""
+Check that a refund input file has the right format BEFORE running a refund.
+
+This is the CLI equivalent of the web UI's "Check file format" button. It runs the
+shared engine's `validate_file_format()` (in `core/engine.py`) and prints a clean
+pass/fail report: which required columns were found/missing, which amount column was
+detected, the data-row count, and any row-level issues (missing agreement_id /
+invoice_id, non-positive amount, or more than 2 decimal places).
+
+It does NOT call AWS and does NOT modify or submit anything. To also split a file
+into a cleaned + needs-review pair, use `clean_refund_file.py`.
+
+Exit code is 0 when the file is valid, 1 when it is not (handy for scripting).
+
+Examples:
+  python check_file_format.py adjustmentFiles/sample_company.csv
+  python check_file_format.py "MongoDb/Harvey Bedrock Refund.csv"
+  python check_file_format.py refunds.csv --json
+"""
+
+import argparse
+import json
+import os
+import sys
+
+import _cli_common  # noqa: F401  (adds repo root to sys.path for `core`)
+from core import validate_file_format
+
+
+def main():
+    ap = argparse.ArgumentParser(
+        description="Validate a refund input file's format (no AWS calls, nothing submitted)."
+    )
+    ap.add_argument("input", help="Refund CSV file (same format as the submit file)")
+    ap.add_argument("--json", action="store_true",
+                    help="Print the raw details dict as JSON instead of a text report")
+    args = ap.parse_args()
+
+    if not os.path.isfile(args.input):
+        print(f"ERROR: input file not found: {args.input}")
+        sys.exit(1)
+
+    is_valid, message, details = validate_file_format(args.input)
+
+    if args.json:
+        print(json.dumps({"valid": is_valid, "message": message, "details": details},
+                         indent=2, default=str))
+        sys.exit(0 if is_valid else 1)
+
+    print(f"File: {args.input}")
+    print(f"Result: {'VALID' if is_valid else 'INVALID'} - {message}")
+    print()
+
+    found = details.get("found_columns") or []
+    print(f"Found columns ({len(found)}): {', '.join(found) if found else '(none)'}")
+
+    missing = details.get("missing_columns") or []
+    if missing:
+        print(f"Missing required column(s): {', '.join(missing)}")
+
+    amount_col = details.get("amount_column_found")
+    if amount_col:
+        print(f"Amount column detected: '{amount_col}'")
+    else:
+        print(f"Amount column detected: (none) - expected one of: "
+              f"{', '.join(details.get('amount_column_options') or [])}")
+
+    print(f"Data rows: {details.get('row_count', 0)}")
+
+    row_issues = details.get("row_issues") or []
+    if row_issues:
+        print(f"\nRow issues ({len(row_issues)}):")
+        for issue in row_issues:
+            print(f"  line {issue.get('line')}: {'; '.join(issue.get('issues', []))}")
+
+    print()
+    if is_valid:
+        print("OK - this file is ready to submit (run a --dry-run for live invoice checks).")
+    else:
+        print("Fix the issues above, or run clean_refund_file.py to split out the bad rows.")
+
+    sys.exit(0 if is_valid else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/applications/billing-adjustments/core/engine.py
+++ b/applications/billing-adjustments/core/engine.py
@@ -809,10 +809,77 @@ class AdjustmentProcessor:
 
         return processed, not_processed, errors
 
-    def run(self, rows, writer, dry_run=False, counters=None):
+    def find_already_processed(self, rows, block_statuses=('COMPLETED', 'PENDING'), cache=None):
+        """Live pre-submission guard against duplicate refunds.
+
+        For each `<agreement, invoice>` in `rows`, check the service for an existing
+        billing adjustment request. A row is treated as **already processed** (and must
+        NOT be resubmitted) when a request exists for its invoice with a status in
+        `block_statuses` (default `COMPLETED`/`PENDING`). Rows whose only existing
+        request(s) are `VALIDATION_FAILED` (no refund actually happened) are still
+        submittable.
+
+        This matters because the deterministic client token only de-duplicates within
+        the API's 8-hour idempotency window; once a run spans or follows that window,
+        this live check is what prevents a second refund.
+
+        Returns (to_submit, already, errors):
+          - to_submit: rows safe to submit (no blocking request found)
+          - already:   rows that already have a blocking request; each is the original
+                       row dict plus 'existing_request_id' and 'existing_status'
+          - errors:    list of {'agreementId', 'error'} for agreements that could not be
+                       verified. Their rows are placed in `to_submit` so a transient
+                       listing failure does not block the run (the client token still
+                       guards within 8h); the caller should surface the warning.
+        """
+        cache = cache if cache is not None else {}
+        to_submit, already, errors = [], [], []
+        by_agreement = defaultdict(list)
+        for r in rows:
+            by_agreement[r['agreement_id']].append(r)
+        for aid, agrows in by_agreement.items():
+            if aid in cache:
+                invoice_map, list_failed = cache[aid]
+            else:
+                items, list_errors = self.list_adjustment_requests([aid], statuses=None)
+                list_failed = bool(list_errors)
+                invoice_map = defaultdict(list)
+                if not list_failed:
+                    for it in items:
+                        inv = str(it.get('originalInvoiceId') or '').strip()
+                        if inv:
+                            invoice_map[inv].append(it)
+                cache[aid] = (invoice_map, list_failed)
+                if list_failed:
+                    for le in list_errors:
+                        errors.append({'agreementId': aid, 'error': le.get('error')})
+            if list_failed:
+                # Could not verify this agreement -> do not block; rely on the token.
+                to_submit.extend(agrows)
+                continue
+            for r in agrows:
+                existing = invoice_map.get(str(r['invoice_id']).strip(), [])
+                blocking = [it for it in existing if it.get('status') in block_statuses]
+                if blocking:
+                    chosen = next((it for it in blocking if it.get('status') == 'COMPLETED'),
+                                  blocking[0])
+                    r2 = dict(r)
+                    r2['existing_request_id'] = chosen.get('billingAdjustmentRequestId')
+                    r2['existing_status'] = chosen.get('status')
+                    already.append(r2)
+                else:
+                    to_submit.append(r)
+        return to_submit, already, errors
+
+    def run(self, rows, writer, dry_run=False, counters=None, precheck_processed=True):
         """
         Main processing. Writes each record as it is resolved.
-        counters: mutable dict to update {total, processed, succeeded, failed}
+        counters: mutable dict to update {total, processed, succeeded, failed, skipped}
+        precheck_processed: for LIVE runs, before submitting each row, check the service
+            for an existing COMPLETED/PENDING adjustment request on the same
+            <agreement, invoice> and skip it (status ALREADY_PROCESSED) instead of
+            risking a duplicate refund once the 8-hour idempotency window has lapsed.
+            Ignored for dry-run. Defaults to True (safe by default).
         Returns a summary dict.
         """
         counters = counters if counters is not None else {}
@@ -821,6 +888,7 @@ class AdjustmentProcessor:
         counters.setdefault('processed', 0)
         counters.setdefault('succeeded', 0)
         counters.setdefault('failed', 0)
+        counters.setdefault('skipped', 0)
 
         # Wrap the writer so we also accumulate $ totals (submitted/completed/failed)
         # for the summary, in addition to the counts. Delegates writes unchanged.
@@ -842,7 +910,12 @@ class AdjustmentProcessor:
             "submitted": 0,
             "succeeded": 0,
             "failed": 0,
+            "already_processed": 0,
         }
+
+        # Cache of existing adjustment requests per agreement, reused across phases so
+        # the live pre-check lists each agreement at most once per run.
+        precheck_cache = {}
 
         # Dry-run only: accumulate per-invoice requested totals to flag when the sum
         # of all rows for one invoice exceeds its maxAdjustmentAmount.
@@ -867,28 +940,6 @@ class AdjustmentProcessor:
                 if is_valid:
                     row['max_adjustment_amount'] = max_amount
                     validated.append(row)
-                    if dry_run:
-                        # In dry-run, a valid invoice is the final result for this record
-                        counters['processed'] += 1
-                        counters['succeeded'] += 1
-                        summary["succeeded"] += 1
-                        agg = dry_run_invoice_totals[row['invoice_id']]
-                        try:
-                            agg["total"] += float(row['amount'])
-                        except (TypeError, ValueError):
-                            pass
-                        agg["max"] = max_amount
-                        agg["rows"] += 1
-                        writer.write({
-                            "phase": phase_num,
-                            "agreement_id": row['agreement_id'],
-                            "invoice_id": row['invoice_id'],
-                            "amount": row['amount'],
-                            "status": "DRY_RUN_OK",
-                            "billing_adjustment_request_id": "",
-                            "message": f"Would submit. Max allowed: {max_amount}",
-                        })
-                        self.progress_cb(**counters)
                 else:
                     counters['processed'] += 1
                     counters['failed'] += 1
@@ -907,11 +958,72 @@ class AdjustmentProcessor:
                     self.progress_cb(**counters)
                 time.sleep(DELAY_BETWEEN_BATCHES)
 
+            if not validated:
+                continue
+
+            # Pre-submission guard — runs for live AND dry-run (when enabled). It skips
+            # any <agreement, invoice> that already has a COMPLETED/PENDING adjustment
+            # request so a re-run (or a run that spans the 8-hour idempotency window)
+            # cannot create a duplicate refund. In dry-run nothing is submitted, but the
+            # already-processed rows are surfaced as a warning and excluded from the
+            # DRY_RUN_OK preview, so the preview reflects only genuinely new refunds.
+            if precheck_processed:
+                self._log("Checking for already-processed refunds...")
+                validated, already_processed, precheck_errors = self.find_already_processed(
+                    validated, cache=precheck_cache
+                )
+                for pe in precheck_errors:
+                    self._log(f"  WARNING: could not verify agreement {pe['agreementId']} "
+                              f"({pe['error']}); its rows are treated as not-yet-processed.")
+                for r in already_processed:
+                    counters['processed'] += 1
+                    counters['skipped'] = counters.get('skipped', 0) + 1
+                    summary["already_processed"] += 1
+                    tail = "; would skip (dry-run)" if dry_run else "; skipping (not resubmitted)"
+                    self._log(f"  invoice {r['invoice_id']} ({r['agreement_id']}): "
+                              f"ALREADY_PROCESSED - existing {r['existing_status']} request "
+                              f"{r['existing_request_id']}{tail}")
+                    writer.write({
+                        "phase": phase_num,
+                        "agreement_id": r['agreement_id'],
+                        "invoice_id": r['invoice_id'],
+                        "amount": r['amount'],
+                        "status": "ALREADY_PROCESSED",
+                        "billing_adjustment_request_id": r.get('existing_request_id', ''),
+                        "message": (f"Skipped: an existing {r['existing_status']} adjustment "
+                                    f"request ({r['existing_request_id']}) already exists for "
+                                    f"this <agreement, invoice>."),
+                    })
+                    self.progress_cb(**counters)
+
             if dry_run:
+                # Record the rows that WOULD be submitted in a live run.
+                for row in validated:
+                    counters['processed'] += 1
+                    counters['succeeded'] += 1
+                    summary["succeeded"] += 1
+                    agg = dry_run_invoice_totals[row['invoice_id']]
+                    try:
+                        agg["total"] += float(row['amount'])
+                    except (TypeError, ValueError):
+                        pass
+                    agg["max"] = row.get('max_adjustment_amount')
+                    agg["rows"] += 1
+                    writer.write({
+                        "phase": phase_num,
+                        "agreement_id": row['agreement_id'],
+                        "invoice_id": row['invoice_id'],
+                        "amount": row['amount'],
+                        "status": "DRY_RUN_OK",
+                        "billing_adjustment_request_id": "",
+                        "message": f"Would submit. Max allowed: {row.get('max_adjustment_amount')}",
+                    })
+                    self.progress_cb(**counters)
                 continue  # No submission in dry-run
 
             if not validated:
                 continue
+
 
             # Submit batches
             grouped = group_by_agreement(validated)

--- a/applications/billing-adjustments/webapp/app.py
+++ b/applications/billing-adjustments/webapp/app.py
@@ -180,6 +180,7 @@ def api_submit():
         return jsonify({"error": "No file selected."}), 400
 
     dry_run = request.form.get("dry_run", "false").lower() == "true"
+    precheck_processed = request.form.get("precheck", "true").lower() == "true"
 
     credentials = None
     if not MANAGED_CREDENTIALS:
@@ -245,6 +246,7 @@ def api_submit():
         assume_role_external_id=ASSUME_ROLE_EXTERNAL_ID,
         review_rows=review_rows,
         review_columns=columns,
+        precheck_processed=precheck_processed,
     )
     return jsonify({
         "job_id": job_id,

--- a/applications/billing-adjustments/webapp/job_manager.py
+++ b/applications/billing-adjustments/webapp/job_manager.py
@@ -80,7 +80,7 @@ class JobManager:
     def create_job(self, csv_path, original_filename, credentials, dry_run=False,
                    managed_credentials=False, assume_role_arn=None,
                    assume_role_external_id=None, review_rows=None,
-                   review_columns=None):
+                   review_columns=None, precheck_processed=True):
         job_id = uuid.uuid4().hex[:12]
         jdir = _job_dir(job_id)
         os.makedirs(jdir, exist_ok=True)
@@ -115,7 +115,7 @@ class JobManager:
             "created_at": datetime.now().isoformat(),
             "started_at": None,
             "finished_at": None,
-            "progress": {"total": 0, "processed": 0, "succeeded": 0, "failed": 0},
+            "progress": {"total": 0, "processed": 0, "succeeded": 0, "failed": 0, "skipped": 0},
             "review_count": len(review_rows),
             "logs": [],
             "summary": None,
@@ -130,7 +130,8 @@ class JobManager:
         thread = threading.Thread(
             target=self._run_job,
             args=(job_id, csv_path, credentials, dry_run, cancel_flag, cred_slot,
-                  managed_credentials, assume_role_arn, assume_role_external_id),
+                  managed_credentials, assume_role_arn, assume_role_external_id,
+                  precheck_processed),
             daemon=True,
         )
         with _lock:
@@ -164,7 +165,7 @@ class JobManager:
 
     def _run_job(self, job_id, csv_path, credentials, dry_run, cancel_flag, cred_slot,
                  managed_credentials=False, assume_role_arn=None,
-                 assume_role_external_id=None):
+                 assume_role_external_id=None, precheck_processed=True):
         jdir = _job_dir(job_id)
         status = read_status(job_id)
 
@@ -183,6 +184,7 @@ class JobManager:
                 "processed": counters.get("processed", 0),
                 "succeeded": counters.get("succeeded", 0),
                 "failed": counters.get("failed", 0),
+                "skipped": counters.get("skipped", 0),
             })
             save()
 
@@ -233,9 +235,10 @@ class JobManager:
                 assume_role_external_id=assume_role_external_id,
             )
 
-            counters = {"total": 0, "processed": 0, "succeeded": 0, "failed": 0}
+            counters = {"total": 0, "processed": 0, "succeeded": 0, "failed": 0, "skipped": 0}
             try:
-                summary = processor.run(rows, writer, dry_run=dry_run, counters=counters)
+                summary = processor.run(rows, writer, dry_run=dry_run, counters=counters,
+                                        precheck_processed=precheck_processed)
             except CredentialsCancelled:
                 summary = {
                     "cancelled": True,
@@ -252,8 +255,10 @@ class JobManager:
             status["summary"] = summary
             status["state"] = "cancelled" if cancel_flag["cancel"] else "completed"
             status["finished_at"] = datetime.now().isoformat()
+            skipped_note = (f", Skipped (already processed): {counters['skipped']}"
+                            if counters.get('skipped') else "")
             log_cb(f"Job {status['state']}. "
-                   f"Succeeded: {counters['succeeded']}, Failed: {counters['failed']}.")
+                   f"Succeeded: {counters['succeeded']}, Failed: {counters['failed']}{skipped_note}.")
             save()
 
         except Exception as e:

--- a/applications/billing-adjustments/webapp/templates/index.html
+++ b/applications/billing-adjustments/webapp/templates/index.html
@@ -158,6 +158,10 @@
           <input type="checkbox" id="dryRun" checked>
           <label for="dryRun">Dry run <span class="hint">(validate only, no adjustments submitted)</span></label>
         </div>
+        <div class="checkbox-row">
+          <input type="checkbox" id="precheck" checked>
+          <label for="precheck">Skip already-processed refunds <span class="hint">(recommended: before submitting, skip any agreement+invoice that already has a COMPLETED/PENDING refund)</span></label>
+        </div>
         <div class="msg" id="submitMsg"></div>
         <div class="btn-row"><button type="button" id="submitBtn">Start job</button></div>
       </div>
@@ -169,8 +173,9 @@
         <div class="stat-grid">
           <div class="stat"><div class="n" id="statTotal">0</div><div class="l">Total</div></div>
           <div class="stat"><div class="n" id="statProcessed">0</div><div class="l">Processed</div></div>
-          <div class="stat"><div class="n" style="color:var(--green)" id="statSucceeded">0</div><div class="l">Succeeded</div></div>
+          <div class="stat"><div class="n" style="color:var(--green)" id="statSucceeded">0</div><div class="l" id="statSucceededLabel">Succeeded</div></div>
           <div class="stat"><div class="n" style="color:var(--red)" id="statFailed">0</div><div class="l">Failed</div></div>
+          <div class="stat"><div class="n" style="color:var(--accent-dark)" id="statSkipped">0</div><div class="l">Skipped</div></div>
         </div>
         <div class="dl-row" id="activeDownloads"></div>
         <div class="msg err" id="credPanel" style="display:none;">
@@ -324,6 +329,7 @@ async function submitJob() {
   const fd = new FormData(); fd.append("file", fileInput.files[0]);
   if (!appendCreds(fd, $("submitMsg"))) return;
   fd.append("dry_run", $("dryRun").checked ? "true" : "false");
+  fd.append("precheck", $("precheck").checked ? "true" : "false");
   $("submitBtn").disabled = true;
   showMsg($("submitMsg"), "info", "Starting job...");
   try {
@@ -369,6 +375,8 @@ function renderActive(job) {
   $("progressBar").style.width = (total ? Math.round((processed / total) * 100) : 0) + "%";
   $("statTotal").textContent = total; $("statProcessed").textContent = processed;
   $("statSucceeded").textContent = p.succeeded || 0; $("statFailed").textContent = p.failed || 0;
+  $("statSkipped").textContent = p.skipped || 0;
+  $("statSucceededLabel").textContent = job.dry_run ? "Would submit" : "Succeeded";
   $("logs").textContent = (job.logs || []).join("\n"); $("logs").scrollTop = $("logs").scrollHeight;
   const done = ["completed", "failed", "cancelled"].includes(job.state);
   $("cancelBtn").style.display = done ? "none" : "inline-block";
@@ -397,7 +405,7 @@ async function loadJobs() {
       const p = job.progress || {}; const done = ["completed", "failed", "cancelled"].includes(job.state);
       return `<div class="job-item"><div><strong>${job.original_filename}</strong>
           <span class="badge ${job.state}">${job.state}</span>${job.dry_run ? ' <span class="hint">(dry run)</span>' : ''}</div>
-          <div class="meta">Created ${job.created_at || '-'} · Total ${p.total||0}, Succeeded ${p.succeeded||0}, Failed ${p.failed||0}${job.review_count ? ', Needs review '+job.review_count : ''}
+          <div class="meta">Created ${job.created_at || '-'} · Total ${p.total||0}, ${job.dry_run ? 'Would submit' : 'Succeeded'} ${p.succeeded||0}, Failed ${p.failed||0}${p.skipped ? ', Skipped '+p.skipped : ''}${job.review_count ? ', Needs review '+job.review_count : ''}
             ${job.error ? '· <span style="color:var(--red)">'+job.error+'</span>' : ''}</div>
           ${done ? '<div class="dl-row">'+downloadLinks(job)+'</div>' : ''}
           ${!done ? '<div class="meta"><a href="#" onclick="trackJob(\''+job.job_id+'\');return false;">Track this job ▸</a></div>' : ''}</div>`;


### PR DESCRIPTION
…eporting - Live + dry-run pre-check: before submitting, skip any agreement+invoice that already has a COMPLETED/PENDING adjustment request (ALREADY_PROCESSED), guarding against duplicate refunds once the 8-hour idempotency window lapses. On by default; CLI --no-precheck / web checkbox to opt out. Dry-run runs it as a preview. - CLI: new check_file_format.py (offline format report); live runs write already_processed_*.csv - Web: 'Skip already-processed refunds' toggle, Skipped stat tile, dry-run 'Would submit' label, skipped surfaced in job history + final log so counts reconcile - Docs: ALREADY_PROCESSED status, pre-check behavior, reconcile-first guidance, and the ListBillingAdjustmentRequests API link

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
