### PR TITLE
feat(engine): per-operation rate pacing + scaled poll budget - Pace e…

### DIFF
--- a/applications/billing-adjustments/README.md
+++ b/applications/billing-adjustments/README.md
@@ -197,7 +197,7 @@ Here is what each value means and what to do about it.
 | `VALIDATION_FAILED` | pre-submit check, **or** service terminal status | Two cases: (a) the row failed the pre-flight check — invoice not found, not an adjustable invoice type (e.g. `CREDIT_MEMO`), or amount > `maxAdjustmentAmount` — so **nothing was submitted**; or (b) a submitted request was rejected by the service during processing (e.g. KYC/compliance, agreement state). | Fix the input/data; the `message` column has the reason. Re-running unchanged won't help. |
 | `SUBMIT_FAILED` | submit (create call) | The row passed validation, the tool called `BatchCreateBillingAdjustmentRequest`, and that call rejected the entry or errored (throttling, permissions, conflict, API error). **No request was created.** | Usually retry-safe — the deterministic client token prevents duplicates. Check the `message`. |
 | `ERROR` | service terminal status | While polling, `GetBillingAdjustmentRequest` returned an error status for the request. | Investigate the `message`; may require AWS Marketplace support. |
-| `TIMEOUT` | polling | The tool stopped waiting after the poll limit (`MAX_POLL_TIME`, 10 min). The request **may still finish** server-side. | Re-check later with **Check one request** (UI) or `check_adjustment_status.py`. Not necessarily a failure. |
+| `TIMEOUT` | polling | The tool stopped waiting after the poll budget elapsed. The budget **scales with the number of pending requests** (floor 10 min, up to a 2-hour cap), so large batches aren't falsely timed out. The request **may still finish** server-side. | Re-check later with **Check one request** (UI) or `check_adjustment_status.py`. Not necessarily a failure. |
 | `PENDING` | in-flight (transient) | Submitted but not yet in a terminal state. Not written as a final row by the Web UI, but shown by the CLI status checker. | Wait and re-check. |
 
 **`VALIDATION_FAILED` vs `SUBMIT_FAILED` in one line:** `VALIDATION_FAILED` means the
@@ -282,10 +282,14 @@ These constants near the top of the shared engine control its behavior:
 |---------|---------|---------|
 | `CSV_FILE` | `adjustmentFiles/sample_company.csv` | Default input file when none is passed on the command line |
 | `BATCH_SIZE` | `5` | Max invoices per `BatchCreateBillingAdjustmentRequest` call |
-| `CALLS_PER_SECOND` | `2` | Client-side API rate limit (TPS) |
-| `DELAY_BETWEEN_BATCHES` | `1.0 / CALLS_PER_SECOND` (0.5s) | Pause between API calls to honor the rate limit |
-| `POLL_INTERVAL` | `60` | Seconds between status polls while waiting for a phase to complete |
-| `MAX_POLL_TIME` | `600` | Max seconds to wait for a phase before marking remaining requests `TIMEOUT` |
+| `CALLS_PER_SECOND` | `2` | Back-compat global default = the slowest (write) path, `BatchCreateBillingAdjustmentRequest`. Each API path is now paced to its **own** quota (see *API rate limits* below). |
+| `DELAY_BETWEEN_BATCHES` / `SUBMIT_DELAY` | `0.5s` | Submit pacing (`BatchCreateBillingAdjustmentRequest`, 2/s). |
+| `GET_DELAY` | `0.2s` | Status-poll pacing (`GetBillingAdjustmentRequest`, 5/s). |
+| `LIST_BILLING_ADJUSTMENTS_DELAY` | `0.2s` | Reconcile + already-processed pre-check pacing (`ListBillingAdjustmentRequests`, 5/s). |
+| `VALIDATE_DELAY` | `0.1s` | Invoice-validation pacing (`ListAgreementInvoiceLineItems`, 10/s). |
+| `POLL_INTERVAL` | `60` | Seconds of idle wait between status sweeps. |
+| `MAX_POLL_TIME` | `600` | Back-compat floor alias (== `MIN_POLL_TIME`). |
+| `MIN_POLL_TIME` / `MAX_POLL_SWEEPS` / `MAX_POLL_TIME_CAP` | `600` / `5` / `7200` | Status-poll budget. The total wait **scales** with the number of pending requests — `MAX_POLL_SWEEPS × (pending / GET_CALLS_PER_SECOND + POLL_INTERVAL)`, clamped between `MIN_POLL_TIME` and `MAX_POLL_TIME_CAP` — so large batches aren't falsely `TIMEOUT`-ed. |
 | `CURRENCY_CODE` | `USD` | Currency sent with each adjustment. The tool currently supports **USD only** — see [Input file format → Currency](#currency). |
 | `ADJUSTMENT_REASON` | `OTHER` | `adjustmentReasonCode` sent with each adjustment |
 | `ENDPOINT_URL` | `https://agreement-marketplace.us-east-1.amazonaws.com` | Marketplace Agreement API endpoint |
@@ -294,6 +298,48 @@ These constants near the top of the shared engine control its behavior:
 (Both the web app and the CLI use the shared engine in `core/engine.py`; these
 constants live there. `CSV_FILE` is a CLI-only default in
 `cli/billing_adjustment_bulk_sdk_creds.py`.)
+
+### API rate limits (service quotas)
+
+The tool paces each API call path to its **own** documented request rate from the
+[AWS Marketplace Agreement service quotas](https://docs.aws.amazon.com/marketplace/latest/developerguide/agreement-service-quotas.html)
+(per AWS account), rather than a single global rate. This keeps the read-heavy phases
+(validation, polling, reconciliation) fast while staying within quota.
+
+| Operation | Tool phase | Quota | Pacing constant |
+|-----------|-----------|-------|-----------------|
+| `BatchCreateBillingAdjustmentRequest` | Submit | 2/s | `SUBMIT_DELAY` (0.5s) |
+| `GetBillingAdjustmentRequest` | Status polling | 5/s | `GET_DELAY` (0.2s) |
+| `ListBillingAdjustmentRequests` | Reconcile + already-processed pre-check | 5/s | `LIST_BILLING_ADJUSTMENTS_DELAY` (0.2s) |
+| `ListAgreementInvoiceLineItems` | Invoice validation | 10/s | `VALIDATE_DELAY` (0.1s) |
+
+The boto3 client also uses adaptive retries, so brief throttling backs off and retries
+automatically. These are the current default quotas — always confirm against the
+[quota page](https://docs.aws.amazon.com/marketplace/latest/developerguide/agreement-service-quotas.html),
+since your account's limits can differ or change.
+
+### Best practices for large refund files
+
+- **Test with a small set first.** Before running a full file, copy ~**20 rows** into a
+  separate CSV and run a **dry run** (and ideally one small live run) against it. This
+  confirms your credentials, file format, and that the agreements/invoices validate —
+  without putting the whole list at risk.
+- **Split very large lists into batches of ~250 rows.** The tool will process a large
+  file in one go, but submission is rate-limited to ~2/second by the
+  `BatchCreateBillingAdjustmentRequest` quota (about 8 minutes per 1,000 single-invoice
+  rows), and it submits the whole file before it starts polling for completion. For
+  large lists, splitting the input into chunks of about **250 rows** per run gives you:
+  - **Progressive results** — completed refunds land after each chunk instead of waiting
+    for the entire file to be submitted first.
+  - **Bounded, predictable poll windows** — fewer requests are in flight at once, so each
+    run's status-poll budget stays small.
+  - **Smaller blast radius** — a credential expiry or interruption affects only the
+    current chunk; already-completed chunks are already saved.
+
+  Chunks much smaller than ~250 are less efficient (they poll before requests have had
+  time to settle, adding status calls), so ~250 is a good balance. Re-running is safe:
+  the already-processed pre-check and the deterministic client token skip anything that
+  was already refunded.
 
 ### Retries on credential failure
 

--- a/applications/billing-adjustments/core/engine.py
+++ b/applications/billing-adjustments/core/engine.py
@@ -26,10 +26,39 @@ from botocore.session import get_session as _get_botocore_session
 
 # Defaults (can be overridden via AdjustmentConfig)
 BATCH_SIZE = 5
-CALLS_PER_SECOND = 2
-DELAY_BETWEEN_BATCHES = 1.0 / CALLS_PER_SECOND
+
+# Per-operation request rates, from the AWS Marketplace Agreement service quotas
+# (per AWS account). Each API call path is paced to its OWN documented limit instead
+# of a single global rate, so the read paths are not throttled down to the slowest
+# (write) limit.
+# https://docs.aws.amazon.com/marketplace/latest/developerguide/agreement-service-quotas.html
+BATCH_CREATE_CALLS_PER_SECOND = 2               # BatchCreateBillingAdjustmentRequest
+GET_CALLS_PER_SECOND = 5                         # GetBillingAdjustmentRequest
+LIST_BILLING_ADJUSTMENTS_CALLS_PER_SECOND = 5   # ListBillingAdjustmentRequests
+LIST_INVOICE_LINE_ITEMS_CALLS_PER_SECOND = 10   # ListAgreementInvoiceLineItems
+
+# Backwards-compatible global default = the most restrictive path (the write/submit).
+# Kept because core/__init__.py re-exports these names and CLI scripts import them.
+CALLS_PER_SECOND = BATCH_CREATE_CALLS_PER_SECOND
+DELAY_BETWEEN_BATCHES = 1.0 / CALLS_PER_SECOND   # submit pacing (2/s -> 0.5s)
+
+# Per-operation inter-call delays (seconds), derived from the quotas above.
+SUBMIT_DELAY = 1.0 / BATCH_CREATE_CALLS_PER_SECOND                                 # 0.50s
+GET_DELAY = 1.0 / GET_CALLS_PER_SECOND                                             # 0.20s
+LIST_BILLING_ADJUSTMENTS_DELAY = 1.0 / LIST_BILLING_ADJUSTMENTS_CALLS_PER_SECOND   # 0.20s
+VALIDATE_DELAY = 1.0 / LIST_INVOICE_LINE_ITEMS_CALLS_PER_SECOND                    # 0.10s
+
+# Status polling. The total budget SCALES with the number of pending requests so a
+# large batch is not falsely timed out: one status sweep of N requests already costs
+# ~ N / GET_CALLS_PER_SECOND seconds in pacing alone. We allow up to MAX_POLL_SWEEPS
+# full sweeps (each followed by a POLL_INTERVAL idle wait), bounded by a floor (so
+# small batches behave as before) and an absolute ceiling. See _compute_poll_budget().
 POLL_INTERVAL = 60
-MAX_POLL_TIME = 600
+MIN_POLL_TIME = 600          # floor in seconds (small batches)
+MAX_POLL_SWEEPS = 5          # number of full status sweeps to allow
+MAX_POLL_TIME_CAP = 7200     # absolute ceiling in seconds (2 hours)
+# Back-compat alias; the effective budget is computed per-run in _wait_and_record.
+MAX_POLL_TIME = MIN_POLL_TIME
 CURRENCY_CODE = "USD"
 ADJUSTMENT_REASON = "OTHER"
 ENDPOINT_URL = "https://agreement-marketplace.us-east-1.amazonaws.com"
@@ -385,6 +414,18 @@ def create_batches(grouped_rows, batch_size):
     return batches
 
 
+def _compute_poll_budget(n_pending):
+    """Total seconds to wait for `n_pending` requests to reach a terminal status.
+
+    The budget scales with the batch so large runs are not falsely timed out: a single
+    status sweep of N requests costs ~ N / GET_CALLS_PER_SECOND seconds of pacing
+    alone, so we budget MAX_POLL_SWEEPS sweeps plus their inter-sweep idle waits,
+    bounded by MIN_POLL_TIME (floor) and MAX_POLL_TIME_CAP (ceiling)."""
+    sweep_cost = n_pending / GET_CALLS_PER_SECOND
+    budget = MAX_POLL_SWEEPS * (sweep_cost + POLL_INTERVAL)
+    return min(MAX_POLL_TIME_CAP, max(MIN_POLL_TIME, int(budget)))
+
+
 class _AmountTally:
     """Wraps a record writer to also accumulate dollar totals by outcome, so the
     run summary can report $ submitted / completed / failed alongside the counts.
@@ -715,7 +756,7 @@ class AdjustmentProcessor:
                     token = resp.get('nextToken')
                     if not token or max_results:
                         break
-                    time.sleep(DELAY_BETWEEN_BATCHES)
+                    time.sleep(LIST_BILLING_ADJUSTMENTS_DELAY)
         return items, errors
 
     def reconcile_refunds(self, records):
@@ -766,6 +807,7 @@ class AdjustmentProcessor:
 
             self._log(f"Listing adjustment requests for agreement {aid}...")
             items, list_errors = self.list_adjustment_requests([aid], statuses=None)
+            time.sleep(LIST_BILLING_ADJUSTMENTS_DELAY)  # pace per-agreement list calls to quota
             if list_errors:
                 # List failed for this agreement -> all its rows are not processed.
                 for le in list_errors:
@@ -803,6 +845,7 @@ class AdjustmentProcessor:
                     detail['matchedInvoiceId'] = invoice_id
                     processed.append(detail)
                     matched_any = True
+                    time.sleep(GET_DELAY)  # pace GetBillingAdjustmentRequest calls to quota
                 if not matched_any:
                     # Listed but could not be confirmed via Get -> not processed.
                     not_processed.append(rec.get('original', {}))
@@ -853,6 +896,10 @@ class AdjustmentProcessor:
                 if list_failed:
                     for le in list_errors:
                         errors.append({'agreementId': aid, 'error': le.get('error')})
+                # Pace successive ListBillingAdjustmentRequests calls (one per agreement)
+                # to the operation's quota; list_adjustment_requests only paces between
+                # pages, not between agreements.
+                time.sleep(LIST_BILLING_ADJUSTMENTS_DELAY)
             if list_failed:
                 # Could not verify this agreement -> do not block; rely on the token.
                 to_submit.extend(agrows)
@@ -956,7 +1003,7 @@ class AdjustmentProcessor:
                         "message": error,
                     })
                     self.progress_cb(**counters)
-                time.sleep(DELAY_BETWEEN_BATCHES)
+                time.sleep(VALIDATE_DELAY)
 
             if not validated:
                 continue
@@ -1100,7 +1147,7 @@ class AdjustmentProcessor:
                             "message": str(e),
                         })
                         self.progress_cb(**counters)
-                time.sleep(DELAY_BETWEEN_BATCHES)
+                time.sleep(SUBMIT_DELAY)
 
             # Poll for completion of this phase's submitted requests
             self._wait_and_record(pending_requests, writer, counters, summary, phase_num)
@@ -1130,11 +1177,13 @@ class AdjustmentProcessor:
         request that stays in progress for a while doesn't look stuck."""
         if not pending_requests:
             return
+        max_poll_time = _compute_poll_budget(len(pending_requests))
         self._log(f"Waiting for {len(pending_requests)} submitted request(s) to complete "
-                  f"(polling every {POLL_INTERVAL}s, up to {MAX_POLL_TIME}s)...")
+                  f"(checks paced at {GET_CALLS_PER_SECOND}/s, polling every "
+                  f"{POLL_INTERVAL}s, up to {max_poll_time}s)...")
         start = time.time()
         poll_round = 0
-        while pending_requests and (time.time() - start) < MAX_POLL_TIME:
+        while pending_requests and (time.time() - start) < max_poll_time:
             if self.cancel_check():
                 break
             poll_round += 1
@@ -1167,12 +1216,12 @@ class AdjustmentProcessor:
                     still_pending.append(req)
                     self._log(f"  invoice {req['invoice_id']} ({req['request_id']}): "
                               f"{status or 'PENDING'}{detail} - still processing; "
-                              f"next status check in {DELAY_BETWEEN_BATCHES:.1f}s")
-                time.sleep(DELAY_BETWEEN_BATCHES)
+                              f"next status check in {GET_DELAY:.1f}s")
+                time.sleep(GET_DELAY)
             pending_requests = still_pending
             if pending_requests:
                 elapsed = int(time.time() - start)
-                remaining = max(0, MAX_POLL_TIME - elapsed)
+                remaining = max(0, max_poll_time - elapsed)
                 self._log(f"{len(pending_requests)} request(s) still pending after {elapsed}s; "
                           f"next poll in {POLL_INTERVAL}s (about {remaining}s left before timeout).")
                 time.sleep(POLL_INTERVAL)
@@ -1188,6 +1237,6 @@ class AdjustmentProcessor:
                 "amount": req['amount'],
                 "status": "TIMEOUT",
                 "billing_adjustment_request_id": req['request_id'],
-                "message": f"Timed out after {MAX_POLL_TIME}s",
+                "message": f"Timed out after {max_poll_time}s",
             })
             self.progress_cb(**counters)


### PR DESCRIPTION
…ach API path to its own AWS Marketplace Agreement service quota: BatchCreate 2/s, Get 5/s, ListBillingAdjustmentRequests 5/s, ListAgreementInvoiceLineItems 10/s (was a single global 2/s) - Scale the status-poll budget with pending count (_compute_poll_budget: floor 600s, up to 5 sweeps, cap 7200s) so large batches aren't falsely TIMEOUT-ed - Pace previously unpaced per-agreement loops in find_already_processed/reconcile_refunds - Keep back-compat constants (CALLS_PER_SECOND/DELAY_BETWEEN_BATCHES/POLL_INTERVAL/MAX_POLL_TIME) - README: rate-limits (service quotas) section + large-file best practices; updated TIMEOUT row

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
